### PR TITLE
Add a missing dependency and a test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ WUnderground PWS site.
 Requirements
 ------------
  * Python >=2.7 and <3.0
- * sqlite3
  * librtlsdr from http://sdr.osmocom.org/trac/wiki/rtl-sdr
+ * libusb 1.0
+ * sqlite3
+
+On Debian based systems it is necessary to ensure the -dev packages of the dependencies
+are installed, i.e.
+apt-get install python-dev libusb-1.0-0-dev librtlsdr-dev
 
 Usage
 -----
@@ -25,7 +30,7 @@ Supported Sensors
  * 5D60 - BHTR968 - Indoor temperature/humidity/pressure
  * 2D10 - RGR968  - Rain gauge
  * 3D00 - WGR968  - Anemometer
- * 1D20 - THGR268 - Outdoor temperature/humidity
+ * 1D20 - THGR268 - Outdoor temperature/humidity (also compatible with THGN132N)
  * 1D30 - THGR968 - Outdoor temperature/humidity
 
 The data formats used for these sensors come from:

--- a/test.py
+++ b/test.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+"""
+Script to check whether any supported sensors can be detected
+"""
+
+from decoder import readRTL
+from parser import parseBitStream
+
+print("Gathering data for 90 seconds")
+bits = readRTL(90)
+
+print("Time's up, decoding the data stream")
+output=parseBitStream(bits,verbose=True)
+print(output)


### PR DESCRIPTION
The README.md file is missing the dependency on libusb. All of the dependencies are available as packages on Debian, I haven't confirmed the necessary sqlite one as I've also written a simple test script that just displays the available data in verbose mode.